### PR TITLE
Shrink binaries

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -10,6 +10,7 @@ CURRENTDIR=`pwd`
 BASEDIR=$(dirname $0)
 : ${GOPATH:=$HOME/gopath/src}
 
+export CGO_ENABLED=0
 go build \
 	-a -ldflags "-s -w" \
 	-gcflags="all=-trimpath=$GOPATH" \

--- a/bin/build
+++ b/bin/build
@@ -9,4 +9,6 @@ CURRENTDIR=`pwd`
 
 BASEDIR=$(dirname $0)
 
-go build -o $CURRENTDIR/out/bbl ./$BASEDIR/../bbl
+go build \
+	-a -ldflags "-s -w" \
+	-o $CURRENTDIR/out/bbl ./$BASEDIR/../bbl

--- a/bin/build
+++ b/bin/build
@@ -8,7 +8,9 @@ echo -e "\nGenerating Binary..."
 CURRENTDIR=`pwd`
 
 BASEDIR=$(dirname $0)
+: ${GOPATH:=$HOME/gopath/src}
 
 go build \
 	-a -ldflags "-s -w" \
+	-gcflags="all=-trimpath=$GOPATH" \
 	-o $CURRENTDIR/out/bbl ./$BASEDIR/../bbl


### PR DESCRIPTION
The binaries [generated](/orange-cloudfoundry/bosh-bootloader/releases) by [travis](/orange-cloudfoundry/bosh-bootloader/blob/master/.travis.yml) could lose some weight by stripping them down.